### PR TITLE
New Logging Engine

### DIFF
--- a/src/main/resources/default_config.properties
+++ b/src/main/resources/default_config.properties
@@ -47,6 +47,9 @@ SILVERPEAS_SENDER_EMAIL=silveradmin@localhost
 # activates the multi-language for contents in Silverpeas. Accepts a coma-separated values among:
 # fr for French, en for English, and de for German
 SILVERPEAS_CONTENT_LANGUAGES=fr
+# The default logging level for Silverpeas's loggers. A value among the following: DEBUG, INFO,
+# WARNING, ERROR.
+SILVERPEAS_LOGGING_LEVEL=WARNING
 
 #
 # The properties to initialize the JVM


### PR DESCRIPTION
Replaces the old and flawed Silvertrace engine by a new logging engine that satisfies the usual logging API and uses in Java.
The new logging engine uses as logging backend the standard Java logging API and provides a specific logging API in the mind to wrap any logging implementation and to adhere to the logging use convention in Silverpeas.
Silvertrace is marked now as deprecated and it is in pending to be replaced by the new logging API. The implementation of Silvertrace has been removed and it uses now directly the new logging API.

Don't forget to merge also the PRs in Silverpeas-Core, Silverpeas-Components and Silverpeas-Distribution.